### PR TITLE
Update shards to crystal 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.1.0
 authors:
   - D. Scott Boggs <scott@tams.tech>
 
-crystal: 0.25.1
+crystal: 1.0.0
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.1.0
 authors:
   - D. Scott Boggs <scott@tams.tech>
 
-crystal: 1.0.0
+crystal: ">= 0.25.0, < 2.0.0"
 
 license: MIT


### PR DESCRIPTION
update to allow error less install on crystal 1.0.0. Currently errors out due to major version change on shards install.

there also should be a new version release as well.