### PR TITLE
Fix for Crystal 1.4.0

### DIFF
--- a/src/colors/color_value.cr
+++ b/src/colors/color_value.cr
@@ -9,7 +9,7 @@ module Colors
   class ColorValue
     def initialize(@value : UInt8 = MIN_INTENSITY); end
 
-    def initialize( value : Int | Float | String | ColorValue )
+    def initialize( value : Int64 | Float64 | String | ColorValue )
       @value = value.to_u8
     end
 


### PR DESCRIPTION
@cmur2 would you mind explaining what the issue with v1.4.0 was, and why this was necessary? It's welcome either way, I'm not sure why the initial implementation restricted values to 64-bit sizing.